### PR TITLE
Changed the example in the README to compile properly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,14 @@ rsync: {
         recursive: true,
         exclude: [".git*","*.scss"]
     },
-    deploy-staging: {
+    "deploy-staging": {
         src: "../dist/",
         dest: "/var/www/site",
         host: "user@staging-host",
         recursive: true,
         syncDest: true
     },
-    deploy-live: {
+    "deploy-live": {
         src: "../dist/",
         dest: "/var/www/site",
         host: "user@live-host",


### PR DESCRIPTION
Javascript does not allow using keys with dashes in object literals. Keys with dashes are used in the README.md file and as an example for grunt-rsync usage. (deploy-live, deploy-staging)

I added some quotation marks which works as intended ("deploy-live", "deploy-staging"):

grunt rsync:deploy-live
