### PR TITLE
Can we get to use this.options() instead of this.data

### DIFF
--- a/tasks/rsync.js
+++ b/tasks/rsync.js
@@ -8,7 +8,7 @@ module.exports = function (grunt) {
 
         var done = this.async();
 
-        var options = this.data;
+        var options = this.options();
 
         var host = typeof options.host === "undefined" ? "" : options.host+":";
 


### PR DESCRIPTION
The idea is to be able to have default options for rsync and then only override specific options on each target, for example:

``` json
rsync: {
    options: {
        args: ['-az'],
        dest: 'some/default/destination,
        dryRun: false,
        exclude: ['.git*', 'node_modules'],
        host: 'user@host,
        recursive: true,
        syncDest: true,
        syncDestIgnoreExcl: true,
    },
    fileType1: {
        options: {
            src: 'some/path,
            dest: 'some/remote/path'
        }
    },
    fileType2: {
        options: {
            src: 'some/other/path'
        }
    }
}
```

This will be way cleaner than having for example:

``` json
rsync: {
    fileType1: {
        src: 'some/path,
        dest: 'some/remote/path',
        args: ['-az'],
        dest: 'some/default/destination,
        dryRun: false,
        exclude: ['.git*', 'node_modules'],
        host: 'user@host,
        recursive: true,
        syncDest: true,
        syncDestIgnoreExcl: true,
    },
    fileType2: {
        src: 'some/other/path',
        args: ['-az'],
        dest: 'some/default/destination,
        dryRun: false,
        exclude: ['.git*', 'node_modules'],
        host: 'user@host,
        recursive: true,
        syncDest: true,
        syncDestIgnoreExcl: true,
    }
}
```

this will still support current functionality and grunt will handle for us extending the inner options object with the outer one
