### PR TITLE
Updating to use rsyncwrapper 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A Grunt multitask for accessing the file copying and syncing capabilities of the
 
 ### Release notes
 
+- `>= 0.5.0` Updated to `rsyncwrapper 0.3.0`.
 - `>= 0.4.0` Updated to `rsyncwrapper 0.2.0`.
 - `>= 0.3.0` Updated to `rsyncwrapper 0.1.0`. Some changes under the hood there, so a minor version bump seems appropriate. `src` values that include wildcards should now be properly expanded by the shell.
 - `>= 0.2.0` Updated task to properly use the config [options](http://gruntjs.com/configuring-tasks#options) object

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-rsync",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "A Grunt task for accessing the file copying and syncing capabilities of the rsync command line utility. Uses the rsyncwrapper npm module for the core functionality.",
   "main": "grunt.js",
   "repository": {


### PR DESCRIPTION
rsyncwrapper 0.3.0 is a fix to correct the order of imports and exports.
rsync --includes before --excludes allow explicit selection of
files to rsync, while rsyncwrapper < 0.3.0 adds --excludes before
--includes, causing includes to be ignored.
