### PR TITLE
print shell command only in case of error

### DIFF
--- a/tasks/rsync.js
+++ b/tasks/rsync.js
@@ -20,10 +20,10 @@ module.exports = function (grunt) {
 
         try {
             rsync(options,function (error,stdout,stderr,cmd) {
-                grunt.log.writeln("Shell command was: "+cmd);
                 if ( error ) {
                     grunt.log.error();
                     grunt.log.writeln(error.toString().red);
+                    grunt.log.writeln("Shell command was: "+cmd);
                     done(false);
                 } else {
                     grunt.log.ok();


### PR DESCRIPTION
It's not needed all the time, maybe it's more useful only when there are errors
