### PR TITLE
Add code to escape non-escaped spaces in file paths

### DIFF
--- a/tasks/rsync.js
+++ b/tasks/rsync.js
@@ -2,13 +2,35 @@
 
 var rsync = require("rsyncwrapper");
 
+var escapeSpaces = function(path) {
+    if (typeof path === "string") {
+        return path.replace(/\b\s/g, "\\ ");
+    } else {
+        return path;
+    }
+};
+
+var escapeSpacesInSrcAndDestPaths = function(options) {
+    // Escape paths in the src, dest, include, exclude, and excludeFirst arguments
+    ["src", "dest", "include", "exclude", "excludeFirst"].forEach(function(optionKey) {
+        var option = options[optionKey];
+        if (typeof option === "string") {
+            options[optionKey] = escapeSpaces(option);
+        } else if (Array.isArray(option) === true) {
+            options[optionKey] = option.map(escapeSpaces);
+        }
+    });
+
+    return options;
+};
+
 module.exports = function (grunt) {
 
     grunt.task.registerMultiTask("rsync","Performs rsync tasks.",function () {
 
         var done = this.async();
 
-        var options = this.options();
+        var options = escapeSpacesInSrcAndDestPaths( this.options() );
 
         grunt.log.writelns("rsyncing "+options.src+" >>> "+options.dest);
 


### PR DESCRIPTION
Not sure if this belongs in `grunt-rsync` or `rsyncwrapper`, but here’s the idea:

Glob patterns aside, given that `grunt-rsync` (and `rsyncwrapper`) are attempts to expose the utility of rsync in a Node environment, I believe there’s a case to be made for automatically ensuring that “Node-like path strings” are correctly handled by these tools behind the scenes.

This is not currently the case with regards to space characters in file paths (passed as, say, the `src` argument to `rsyncwrapper`). Today, a JavaScript string like `"/Volumes/My Disk/Source Folder"` is passed directly to `rsync`, unquoted, without escaping space characters. This leads to rsync errors (e.g. rsync error 12, since the source path is not escaped).

Of course, it’s possible to escape space characters in a number of locations before those strings reach `grunt-rsync` or `rsyncwrapper`, but when those paths may be used in other Node code that doesn’t require space escapes, those paths being passed to `grunt-rsync` start requiring postfixes.

Hence, this commit makes an attempt to escape space characters in any path passed to `rsyncwrapper`’s arguments, before handing them off to `rsyncwrapper` itself.

Again, maybe this change should be made to rsyncwrapper instead? Maybe this change is entirely inappropriate? Would be happy to discuss.
